### PR TITLE
fix readme location in pavement

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -54,7 +54,7 @@ project = dict(
     zip_safe = True,
     data_files = [
         ("EGG-INFO", [
-            "README", "LICENSE", "debian/changelog",
+            "README.rst", "LICENSE", "debian/changelog",
         ]),
     ],
 


### PR DESCRIPTION
README was renamed in b8e2286, now, my build complains of a missing readme 
file. Attached code fixes the issue.